### PR TITLE
fix: sign Paidy receiver callbacks with site_hash and add per-application resend

### DIFF
--- a/.claude/skills/padiy-review/SKILL.md
+++ b/.claude/skills/padiy-review/SKILL.md
@@ -52,17 +52,28 @@ R3: (R2でCritical/Highが出た場合のみ) 修正 → 最終判定
    - `main` で `origin/main` より進んでいる: `BASE=origin/main`
    - `main` で `origin/main` と一致し、未コミット変更のみ: `BASE=HEAD`
    - 上記いずれにも差分が無い: レビュー対象が無い。範囲（例: `HEAD~3`）をユーザーに確認する
-3. R1 の対象差分は `git diff $BASE`（ワーキングツリーまで含む）。ステージ済み/未ステージを問わない
-4. **ラウンド境界のスナップショット**: 各ラウンドの「レビュー対象」と「修正後」の状態を
+3. **未追跡ファイルを先に取り込む**。`git diff` も `git stash create` も未追跡ファイルを含まないため、
+   新規の Controller / Service / migration / テストがレビューとスナップショットから漏れる。
+   ラウンド開始時（および修正後のスナップショット前）に必ず:
+   ```bash
+   git ls-files --others --exclude-standard     # 未追跡ファイルの一覧を R<n>.md に記録
+   git add -A                                    # 内容は変えずインデックスに載せる（コミットはしない）
+   ```
+   `git add -N`（intent-to-add）は `git diff` には効くが `git stash create` が
+   「Entry not uptodate. Cannot merge」で失敗するので使わない。
+   `git add -A` でレビュー対象外のゴミ（一時ファイル等）まで載る場合は、その旨をユーザーに伝えて除外する
+4. R1 の対象差分は `git diff $BASE`（ステージ済み + 未ステージ + 手順3で取り込んだ新規ファイル）
+5. **ラウンド境界のスナップショット**: 各ラウンドの「レビュー対象」と「修正後」の状態を
    `git stash create` で作る（ブランチもワーキングツリーも変更しない）:
    ```bash
-   SNAP=$(git stash create "padiy-review R1 target") ; echo ${SNAP:-$(git rev-parse HEAD)}
+   git add -A && SNAP=$(git stash create "padiy-review R1 target") ; echo ${SNAP:-$(git rev-parse HEAD)}
    ```
    空文字が返る（= ワーキングツリーがクリーン）場合は `HEAD` を使う。
-   得られた sha を R<n>.md に記録し、次ラウンドの差分起点にする（`git diff <前ラウンド修正後SNAP>`）。
+   得られた sha を R<n>.md に記録し、次ラウンドの差分起点にする（`git diff <前ラウンド修正後SNAP>`。
+   この diff には前ラウンド以降に追加した新規ファイルも含まれる）。
    stash create のオブジェクトは同一セッション内で参照できれば十分。消えていた場合は
    R<n>.md に記録した**修正ファイル一覧**を対象に `git diff $BASE -- <files>` で代替する
-5. ユーザーが途中でコミットを指示した場合は、以降の起点をそのコミット sha に置き換えてよい
+6. ユーザーが途中でコミットを指示した場合は、以降の起点をそのコミット sha に置き換えてよい
 
 ## ラウンドの自動判定
 
@@ -70,11 +81,14 @@ R3: (R2でCritical/Highが出た場合のみ) 修正 → 最終判定
 置換したもの（例: `fix/signed-callback-resend` → `fix-signed-callback-resend`）。
 `main` 直接作業の場合は `main-<YYYYMMDD>`。
 
-1. `docs/reviews/<dir>/` 内の既存 `R*.md` を確認
-   - 無ければ **R1**
-   - `R1.md` があれば **R2**、`R2.md` があれば **R3**
-   - `R3.md` まで存在する場合はループ完了済み。再実行せず、ユーザーに
-     「ループは完了しています。新規ループを始めるなら reset を指示してください」と伝える
+1. `docs/reviews/<dir>/` 内の既存 `R*.md` を確認し、**最新ラウンドの判定行**（`- 判定:`）で決める
+   - `R*.md` が無ければ **R1**
+   - 最新が `R1.md`: 判定が APPROVE かつ「修正ファイル」が無い（修正ゼロ）なら**完了**。
+     それ以外（修正を行った、または CHANGES REQUESTED）なら **R2**
+   - 最新が `R2.md`: 判定が APPROVE なら**完了**。新規 Critical/High が出て修正した場合のみ **R3**
+   - 最新が `R3.md`: **完了**（判定にかかわらず。未収束なら R3.md にその旨が記録されている）
+   - 完了済みの場合は再実行せず、ユーザーに
+     「ループは完了しています（最終判定: <R<n> の判定>）。新規ループを始めるなら reset を指示してください」と伝える
 2. ユーザーが「reset」「最初から」と言った場合は `R*.md` を `archive/` へ移動して R1 から開始
 3. 各ラウンド開始時に `git rev-parse HEAD` とスナップショット sha を R<n>.md の冒頭に明記する
 

--- a/.claude/skills/padiy-review/SKILL.md
+++ b/.claude/skills/padiy-review/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: padiy-review
+description: >
+  padiy-app（Paidy 加盟店申込の中継 Laravel アプリ）専用の収束型コードレビューループ。
+  このリポジトリで「レビューして」「再レビュー」「レビューを回して」「マージ前チェック」
+  「review-loop」「padiy-review」と言われたら、汎用の review-loop ではなく必ずこのスキルを使う。
+  「新規 Critical/High ゼロ」を APPROVE 条件とし、最大3ラウンドで必ず終了する。
+  Laravel 10 / Paidy・Japanized for WooCommerce 連携の契約に基づく重大度判定、
+  SQLite でのテスト実行、コミットせずワーキングツリーに残す運用（stash スナップショット）を組み込み済み。
+---
+
+# padiy-review — padiy-app 専用の収束型レビューループ
+
+「指摘ゼロ」を目指さない。**新規 Critical/High がゼロになったら APPROVE で終了**する
+レビューループを、最大3ラウンドで実行する。汎用 `review-loop` をこのリポジトリ向けに
+特化したもので、フローは同じ・判定基準と手順だけがこのアプリ向けになっている。
+
+## このリポジトリの前提（レビュー前に必ず把握する）
+
+| 項目 | 内容 |
+|---|---|
+| スタック | Laravel 10 / PHP ^8.1 / Blade + Alpine.js + Tailwind (Vite) / MySQL(本番) |
+| 役割 | WooCommerce プラグイン (Japanized for WooCommerce) からの Paidy 申込を受け、CSV を Paidy へ SFTP/Box 転送し、審査結果と API キーを加盟店サイトへ暗号化して送り返す中継サーバー |
+| コーディング規約 | **Laravel Pint（PSR-12 系）**。WordPress Coding Standards は適用しない |
+| 差分の基点 | `origin/main`（= artisanworkshop/padiy-app）。作業は `fix/*` 等のブランチか、まれに `main` 直接 |
+| コミット | **ユーザーの明示的な指示があるまで commit / push しない**（グローバル CLAUDE.md）。修正はワーキングツリーに残す |
+| テスト | `DB_CONNECTION=sqlite DB_DATABASE=":memory:" php artisan test`（MySQL 不要）。既知の既存失敗あり（後述） |
+| 外部契約 | プラグイン受信 API・Paidy CSV 列順・申込番号形式など。詳細は `references/review-checklist.md` |
+
+レビュー観点・重大度の具体例・外部契約の一覧は **`references/review-checklist.md` を先に読む**こと。
+
+## 全体フロー
+
+```
+R1: フルレビュー → Critical/High/Medium を修正（ワーキングツリー上）
+R2: R1修正差分のみ再レビュー（検証モード） → Critical/High のみ修正
+R3: (R2でCritical/Highが出た場合のみ) 修正 → 最終判定
+その後: ユーザー指示でコミット → PR (artisanworkshop/main 宛) → Copilot を独立最終ゲート
+```
+
+- Low・差分範囲外の指摘は**修正せず** `docs/review-backlog.md` へ追記する
+- `docs/review-baseline.md` に記載済みの許容項目は**指摘しない**
+- R3 終了時点で Critical/High が残る場合のみ、ユーザーに判断を委ねる（無限ループ禁止）
+
+## レビュー対象範囲の決定
+
+コミットせずに進める前提なので、**「コミット済み差分 + ワーキングツリーの未コミット差分」を常に1つの対象**として扱う。
+
+1. `git branch --show-current` でブランチ名を取得
+2. 基点を決める:
+   - フィーチャーブランチ: `BASE=$(git merge-base origin/main HEAD)`
+   - `main` で `origin/main` より進んでいる: `BASE=origin/main`
+   - `main` で `origin/main` と一致し、未コミット変更のみ: `BASE=HEAD`
+   - 上記いずれにも差分が無い: レビュー対象が無い。範囲（例: `HEAD~3`）をユーザーに確認する
+3. R1 の対象差分は `git diff $BASE`（ワーキングツリーまで含む）。ステージ済み/未ステージを問わない
+4. **ラウンド境界のスナップショット**: 各ラウンドの「レビュー対象」と「修正後」の状態を
+   `git stash create` で作る（ブランチもワーキングツリーも変更しない）:
+   ```bash
+   SNAP=$(git stash create "padiy-review R1 target") ; echo ${SNAP:-$(git rev-parse HEAD)}
+   ```
+   空文字が返る（= ワーキングツリーがクリーン）場合は `HEAD` を使う。
+   得られた sha を R<n>.md に記録し、次ラウンドの差分起点にする（`git diff <前ラウンド修正後SNAP>`）。
+   stash create のオブジェクトは同一セッション内で参照できれば十分。消えていた場合は
+   R<n>.md に記録した**修正ファイル一覧**を対象に `git diff $BASE -- <files>` で代替する
+5. ユーザーが途中でコミットを指示した場合は、以降の起点をそのコミット sha に置き換えてよい
+
+## ラウンドの自動判定
+
+レビュー結果は `docs/reviews/<dir>/R<n>.md` に保存する。`<dir>` はブランチ名の `/` を `-` に
+置換したもの（例: `fix/signed-callback-resend` → `fix-signed-callback-resend`）。
+`main` 直接作業の場合は `main-<YYYYMMDD>`。
+
+1. `docs/reviews/<dir>/` 内の既存 `R*.md` を確認
+   - 無ければ **R1**
+   - `R1.md` があれば **R2**、`R2.md` があれば **R3**
+   - `R3.md` まで存在する場合はループ完了済み。再実行せず、ユーザーに
+     「ループは完了しています。新規ループを始めるなら reset を指示してください」と伝える
+2. ユーザーが「reset」「最初から」と言った場合は `R*.md` を `archive/` へ移動して R1 から開始
+3. 各ラウンド開始時に `git rev-parse HEAD` とスナップショット sha を R<n>.md の冒頭に明記する
+
+## 重大度定義（全ラウンド共通）
+
+| 重大度 | 定義（padiy-app 向け） |
+|---|---|
+| **Critical** | セキュリティ脆弱性（SQLi: `DB::raw`/`whereRaw` への未バインド入力、XSS: `{!! !!}` への未エスケープ出力、CSRF: `VerifyCsrfToken::$except` の追加、認証: `auth` ミドルウェア無しの新規 web ルート、mass assignment: `$request->all()` を `$guarded=[]` モデルへ）、**秘密情報の漏洩**（`secret_live_key` / `site_hash` / 暗号鍵をログ・レスポンス・CSV へ平文出力）、**暗号・署名の破壊**（AES 鍵/IV 導出式・`OPENSSL_RAW_DATA`・HMAC 署名対象文字列の変更）、データ破壊（applications/sites の破壊的マイグレーション、加盟店リスト CSV の上書き・消失） |
+| **High** | **外部契約の破壊**（プラグイン受信 API のペイロード/ヘッダー/パス、state トークン形式、Paidy CSV の列順、申込番号形式、旧プラグイン互換）、明確なバグ（null 参照、未定義変数、例外未捕捉で 500）、新規入力のバリデーション欠落、`POST /api/applications` で DB 登録後に 5xx を返す変更（孤児 state トークンを生む）、マイグレーションとモデル/フォームの不整合、スケジュール・SFTP・Box 転送の動作破壊、既存テストの失敗 |
+| **Medium** | N+1、外部 HTTP 呼び出しの timeout 未設定、変更した Controller/Service にテストが無い、個人情報（email/phone/生年月日）の不要なログ出力、ハードコードされた設定値（`.env`/`config` へ逃がすべきもの）、エラーハンドリング不足（CSV 取込で1行の失敗が全体を止める等） |
+| **Low** | Pint スタイル違反、命名、コメント、日本語メッセージの表記ゆれ、リファクタ提案、未使用 `use` |
+
+判定に迷ったら低い方に倒す（重大度インフレを防ぐ）。
+**既存コードに元からある問題**（例: `BasicAuthMiddleware` のハードコード認証情報）は差分範囲外なら
+指摘欄ではなく「対象外指摘」→ backlog へ。
+
+## R1: フルレビュー
+
+対象: 上記で決めた `git diff $BASE`。
+
+手順:
+1. `docs/review-baseline.md` を読む（無ければ後述のテンプレートで作成）
+2. `references/review-checklist.md` の観点で差分をレビューし、`docs/reviews/<dir>/R1.md` に出力
+3. 自動チェックを実行し、結果を R1.md の「自動チェック」欄に記録する:
+   ```bash
+   # 構文
+   git diff --name-only $BASE -- '*.php' | xargs -I{} php -l {}
+   # スタイル（違反は Low。--test なので書き換えない）
+   git diff --name-only $BASE -- '*.php' | xargs vendor/bin/pint --test
+   # テスト
+   DB_CONNECTION=sqlite DB_DATABASE=":memory:" php artisan test
+   ```
+   既知の既存失敗（差分と無関係なら指摘しない）:
+   - 「screen can be rendered」系 — `public/build/manifest.json` 未ビルド。自作テストは `setUp` で `$this->withoutVite()`
+   - PHP 8.4 + 旧 vendor の「Implicitly marking parameter as nullable」deprecation ノイズ
+4. 差分範囲**外**の既存コードへの指摘は「対象外指摘」セクションに分離する
+5. Critical/High が1件も無ければ冒頭に **APPROVE** と明記する
+
+出力フォーマット:
+
+```markdown
+# R1 レビュー結果
+- 対象: <BASE sha>...<HEAD sha> + working tree（対象SNAP: <sha>）
+- 判定: APPROVE / CHANGES REQUESTED
+- 自動チェック: php -l OK / pint N件 / test X passed, Y failed（既知: Z）
+
+## 指摘
+### [R1-1][Critical][app/Services/PaidyCallbackSender.php:42]
+内容の説明（1〜3行）
+**修正方針:** 1行で
+
+## 対象外指摘（差分範囲外）
+- [R1-X1][Medium][...] ...
+
+## Low（backlogへ）
+- [R1-L1][Low][...] ...
+```
+
+6. レビュー後、**Critical/High/Medium をすべて修正**する（ワーキングツリー上。コミットしない）。
+   各修正には R1.md の該当指摘に「→ 修正済み: <ファイル:行>」を追記する
+7. 修正後にテストを再実行し、新規失敗が無いことを確認する
+8. Low と対象外指摘は `docs/review-backlog.md` に追記する（修正しない）
+9. R1.md 末尾に以下を追記する:
+   ```
+   修正後SNAP: <git stash create の sha>
+   修正ファイル: app/..., app/...
+   ```
+
+## R2: 検証再レビュー
+
+対象: `git diff <R1 の対象SNAP>`（= R1 の修正で変更された差分のみ）。
+
+これは**自由探索ではなく検証タスク**である:
+
+1. R1.md を読み、Critical/High/Medium の各指摘IDについて **解消 / 未解消** を1件ずつ判定する
+2. R1 の修正によって**新たに混入した**問題のみ、新規指摘として [R2-連番] で報告する
+   （特に: 修正で外部契約を壊していないか、テストが通るか）
+3. 禁止事項:
+   - R1 で指摘済み・許容済み・backlog 送りにした項目を別の表現で再指摘しない
+   - 差分起点より前から存在するコードへの新規指摘をしない（見つけたら backlog へ）
+4. テストを再実行し結果を記録する
+5. 新規 Critical/High がゼロなら冒頭に **APPROVE** → **ループ終了**
+6. 新規 Critical/High があれば修正し、修正後SNAP を記録して R3 へ
+
+出力は R1 と同フォーマットで `R2.md` に保存。冒頭に R1 指摘の解消判定表を付ける:
+
+```markdown
+## R1 指摘の解消判定
+| ID | 重大度 | 判定 |
+|---|---|---|
+| R1-1 | Critical | 解消 |
+| R1-2 | High | 未解消 → 下記 R2-1 参照 |
+```
+
+## R3: 最終ラウンド（R2 で Critical/High が出た場合のみ）
+
+R2 と同じ検証モードで実行し、対象は R2 修正差分のみ。
+
+- 新規 Critical/High ゼロ → **APPROVE、ループ終了**
+- まだ Critical/High が残る場合 → **修正せずに停止**し、ユーザーに報告:
+  「3ラウンドで収束しませんでした。設計レベルの問題の可能性があります。
+  該当指摘: [一覧]。個別に対応方針を相談してください」
+
+R3 を超えてループを続けてはならない。
+
+## ループ終了後
+
+APPROVE が出たら以下をユーザーに提示する:
+
+1. 全ラウンドのサマリ（指摘数・修正数・backlog送り数・テスト結果）
+2. **ワーキングツリーに残っている変更の一覧**（`git status --short`）と、
+   コミットするかどうかの判断依頼。コミットメッセージ案（英語、対応した指摘IDを含める）を添える
+3. 次のステップの提案:
+   - `start-task` スキルで issue → コミット → push → PR（`artisanworkshop/main` 宛）
+   - PR 上の Copilot レビューを独立最終ゲートとし、指摘は `fix-copilot-review` スキルで処理。
+     その際「最終ゲートで出た指摘は Critical/High のみ修正、他は backlog」というルールを添える
+   - プラグイン側（Japanized for WooCommerce）にも変更が必要な契約変更が含まれる場合は、
+     その旨と該当ファイル（`includes/gateways/paidy/class-wc-paidy-apply-receiver.php` 等）を明記する
+
+## docs/review-baseline.md（無ければ初回に作成）
+
+```markdown
+# レビューベースライン（許容済み指摘リスト）
+レビュー時、ここに記載された項目は指摘しないこと。
+
+## 形式
+- [カテゴリ] 対象範囲 — 許容理由
+
+## 許容項目
+<!-- 例:
+- [Auth] POST /api/applications が認証なし — WooCommerce プラグインからの申込受付口のため（site_hash で後続を検証）
+- [Legacy] routes/web.php の box ルートが auth 無し — 手動運用の暫定ルート
+-->
+```
+
+初回作成時は例をコメントとして残し、実際の許容項目は**ユーザーに確認して**追記する。
+`references/review-checklist.md` の「baseline 候補」も確認の材料にする。
+
+## docs/review-backlog.md（無ければ初回に作成）
+
+```markdown
+# レビューバックログ（今回対応しない指摘）
+| 追記日 | ID | 重大度 | 場所 | 内容 | 起票状況 |
+|---|---|---|---|---|---|
+```
+
+ラウンドごとに追記する。GitHub Issue 化するかはユーザーに確認する
+（起票する場合は `gh issue create`。`docs/issues/` の調査報告形式に合わせてもよい）。
+
+## 注意事項
+
+- レビューと修正は同一セッションで行う（stash スナップショットとコンテキスト維持が収束の前提）。
+  セッションを跨ぐ場合は `--resume` で再開してからこのスキルを使う
+- 他セッションが同じワーキングツリーで作業している可能性がある。ラウンド開始時に
+  `git status --short` を確認し、自分の修正ではない変更が増えていたらユーザーに確認する
+- レビュー範囲の拡大（「ついでに全体も見て」等）を求められた場合は、
+  本ループとは別タスクとして扱い、ループの差分スコープを崩さない
+- プラグイン側リポジトリのローカルコピーは macOS 権限で読めない。契約の突き合わせが必要なら
+  `gh api repos/artisanworkshop/Japanized-for-WooCommerce/contents/<path>` で参照する

--- a/.claude/skills/padiy-review/references/review-checklist.md
+++ b/.claude/skills/padiy-review/references/review-checklist.md
@@ -46,7 +46,9 @@
 - 入力列: `[0]=application_id (WC…)`, `[1]=paidy_status`, `[2]=public_live_key`, `[3]=secret_live_key`,
   `[4]=public_test_key`, `[5]=secret_test_key`。`approved` のときはキー 4 つ必須
 - 1 行ごとに `applications` を更新し、`PaidyCallbackSender` で加盟店へ送信、`set_status` に成否を記録
-- `state` が空/不正な行は送信をスキップしてエラー表示（`docs/issues/csv-import-null-error.md` の経緯を参照）
+- **`state` は任意**。空/不正でも送信を**スキップしない**（署名付きで送り、プラグイン 2.9.16+ の署名検証に委ねる。
+  2.9.15 以前は 403 `paidy_invalid_state` になり、`translateError()` がプラグイン更新を案内する）。
+  「state が無い行は送らない」に戻す変更は、旧プラグインからの申込を再び配信不能にする回帰なので High
 - ファイルバリデーション（`required|file|mimes:...|max:`）が無効化されていないか
 - 1 行の失敗でループ全体が止まらないか、成功/失敗一覧（`api_success_list` / `api_error_list`）に反映されるか
 
@@ -109,11 +111,13 @@ baseline に入れたものは以後のラウンドで指摘しない。
 ```bash
 # 差分の基点
 BASE=$(git merge-base origin/main HEAD)          # フィーチャーブランチ
-git diff --stat $BASE                             # 対象ファイル一覧（working tree 含む）
+git ls-files --others --exclude-standard          # 未追跡ファイル（git diff に出ないので必ず確認）
+git add -A                                        # 未追跡ファイルをインデックスに載せる（コミットはしない）
+git diff --stat $BASE                             # 対象ファイル一覧（working tree + 新規ファイル）
 
-# スナップショット（ブランチ・working tree を変更しない）
-SNAP=$(git stash create "padiy-review R1 target"); echo ${SNAP:-$(git rev-parse HEAD)}
-git diff <SNAP>                                   # スナップショット以降の差分
+# スナップショット（ブランチ・working tree を変更しない。git add -A 済みであること）
+git add -A && SNAP=$(git stash create "padiy-review R1 target"); echo ${SNAP:-$(git rev-parse HEAD)}
+git diff <SNAP>                                   # スナップショット以降の差分（新規ファイル含む）
 
 # 静的チェック
 git diff --name-only $BASE -- '*.php' | xargs -I{} php -l {}

--- a/.claude/skills/padiy-review/references/review-checklist.md
+++ b/.claude/skills/padiy-review/references/review-checklist.md
@@ -1,0 +1,129 @@
+# padiy-app レビューチェックリスト
+
+`padiy-review` スキルの各ラウンドで参照する、このリポジトリ固有の観点集。
+重大度の最終判定は SKILL.md の定義に従う（ここは「何を見るか」の一覧）。
+
+## 1. 外部契約（壊すと High、秘密が漏れれば Critical）
+
+### 1-a. 申込受付 API: `POST /api/applications`（`app/Http/Controllers/Api/ApplicationController.php`）
+
+- 呼び出し元は Japanized for WooCommerce プラグインの申込ウィザード。**認証なし**は設計上の前提
+- 受け取るフィールド: `site_name`, `site_url`, `trade_name`, `site_hash`, `email`, `phone`, `ceo`,
+  `ceo_kana`, `ceo_birthday`, `gmv_flag`, `average_flag`, `state`, `plugin_version`, `survey01`〜`survey09`
+- `state` は 32 文字英数字（`/^[A-Za-z0-9]{32}$/`）。**形式不正でも拒否しない**（旧プラグイン互換）
+- 申込番号は `'WC' . sprintf('%08d', n) . '1'` 形式（例 `WC000005711`）。CSV 取込側は `substr($row[0],0,2) === 'WC'` で判定
+- **DB 登録後に 5xx を返してはならない**。プラグインは 5xx を「申込未達」とみなして state トークンを削除し、
+  後の審査結果送信が 403 `paidy_invalid_state` になる（孤児トークン）。CSV 追記失敗は捕捉してログのみ
+- レスポンスは `response()->json($application)`。プラグインが参照するキーを削除・改名しない
+- `Site` は `site_url` で既存検索 → 無ければ作成。`site_hash` は後続の暗号化・署名の鍵になる
+
+### 1-b. 加盟店サイトへの審査結果送信（`app/Services/PaidyCallbackSender.php`）
+
+- 送信先: `rtrim(site_url,'/') . '/' . 'wp-json/paidy-receiver/v1/receive/'`
+- 認証は 2 系統を**常に両方**送る:
+  - `state`（プラグイン 2.9.13〜2.9.14 は 2 日で失効、2.9.15 は 90 日）
+  - HMAC-SHA256: 署名対象 `"<timestamp>.<raw body>"`、鍵 `site_hash`、
+    ヘッダー `X-Paidy-Receiver-Timestamp` / `X-Paidy-Receiver-Signature`（プラグイン 2.9.16+ が検証）
+  - **署名した文字列と送信本文は完全一致**が必要。`json_encode` のフラグや `withBody` を変えるときは要注意
+- ペイロード: `application_id`, `paidy_status`(`approved|rejected|canceled`), `updated_at`,
+  `public_live_key`, `secret_live_key`, `public_test_key`, `secret_test_key`（各 AES 暗号化 → base64）, `state`(任意)
+- 暗号化: `AES-256-CBC`, key = `substr(hash('sha256', site_hash), 0, 32)`,
+  iv = `substr(hash('sha256', site_hash . 'iv'), 0, 16)`, **`OPENSSL_RAW_DATA` 必須**（受信側と同じ導出式）
+- 受信側のエラーコード `paidy_invalid_state` / `paidy_not_configured` は `translateError()` で日本語化。新コードを足すならここ
+- 変更が受信側（プラグインの `includes/gateways/paidy/class-wc-paidy-apply-receiver.php`）にも
+  必要なら、レビュー結果に**必ず明記**する
+
+### 1-c. Paidy 向け加盟店リスト CSV（`storage/box_data/woocommerce_merchant_list.csv`）
+
+- `Api\ApplicationController::appendMerchantListCsv()` が 1 申込 1 行追記。初回のみ BOM + ヘッダー行
+- **列順・列数（54 列）は Paidy 側の取込仕様**。列の追加・削除・並べ替えは High
+- `Console/Kernel::schedule()` が 6 時間ごとに `Storage::disk('local')` → `Storage::disk('sftp')` へ put。
+  Box へは `routes/web.php` の `/box` ルートで `uploadRevision`
+- ファイル名・保存先ディスクの変更はスケジュールと Box 転送の両方に波及する
+
+### 1-d. Paidy からの審査結果 CSV 取込（`app/Http/Controllers/CsvImportController.php`）
+
+- 入力列: `[0]=application_id (WC…)`, `[1]=paidy_status`, `[2]=public_live_key`, `[3]=secret_live_key`,
+  `[4]=public_test_key`, `[5]=secret_test_key`。`approved` のときはキー 4 つ必須
+- 1 行ごとに `applications` を更新し、`PaidyCallbackSender` で加盟店へ送信、`set_status` に成否を記録
+- `state` が空/不正な行は送信をスキップしてエラー表示（`docs/issues/csv-import-null-error.md` の経緯を参照）
+- ファイルバリデーション（`required|file|mimes:...|max:`）が無効化されていないか
+- 1 行の失敗でループ全体が止まらないか、成功/失敗一覧（`api_success_list` / `api_error_list`）に反映されるか
+
+## 2. Laravel セキュリティ観点
+
+| 観点 | 見る場所 | 重大度の目安 |
+|---|---|---|
+| SQL インジェクション | `DB::raw`, `whereRaw`, `selectRaw`, `orderByRaw` に文字列連結（`kyslik/column-sortable` の sort 列は `$sortable` で制限されているか） | Critical |
+| XSS | Blade の `{!! !!}`、`@json` に未検証データ、`resources/views/**` | Critical |
+| CSRF | `VerifyCsrfToken::$except` の追加、`@csrf` 抜け | Critical |
+| 認可 | `routes/web.php` の新規ルートが `auth` グループの外、`application/{application}/resend` 等の所有者チェック | Critical |
+| mass assignment | `Application` は `$guarded=['id']`、`BoxToken` は `$guarded=[]`。`::create($request->all())` は禁止 | Critical |
+| 秘密情報 | `secret_live_key` / `site_hash` / 暗号鍵 / SFTP・Box 認証情報を `Log::*`・レスポンス・Blade・CSV に出していないか。`Log::info` に申込データ全体を渡していないか | Critical |
+| 個人情報 | `email` / `phone` / `ceo_birthday` を不要にログ出力 | Medium |
+| ファイルアップロード | `mimes`/`max` 検証、保存パスにユーザー入力を使っていないか、`Storage::path()` のパストラバーサル | Critical〜High |
+| 外部 URL への送信 | `site_url` は加盟店入力値。新たに任意 URL へ HTTP を発行する処理を足すなら scheme/host の検証 | High |
+| ハードコード認証情報 | `BasicAuthMiddleware`（既存。差分範囲外なら backlog） | 差分内なら Critical |
+| Sanctum | `auth:sanctum` ルートの追加時、トークン発行経路と `abilities` | High |
+
+## 3. Laravel 正確性・品質観点
+
+- **バリデーション**: 新しい入力は FormRequest（`app/Http/Requests/`）か `$request->validate()` を通す。
+  `$request->foo` を検証なしで DB へ入れていないか
+- **null 安全**: `$request->file()` / `->first()` / `->json('code')` の null を扱っているか（過去障害: `getClientOriginalExtension() on null`）
+- **例外**: ユーザー操作（CSV 取込・再送信・パスワードリセット）で外部 I/O の例外が 500 にならず、画面にエラー表示されるか
+- **外部 HTTP**: `Http::` に `timeout()` / `retry()` があるか（過去障害: SMTP 60 秒タイムアウト）。無ければ Medium
+- **マイグレーション**: モデル/フォーム/CSV 列に追加した属性に対応する migration があるか。
+  本番は `git pull` → `php artisan migrate` 運用なので、破壊的変更（列削除・型変更）は High
+- **スケジュール/キュー**: `Console/Kernel` の変更は本番 cron（`php artisan schedule:run`）で動く。`QUEUE_CONNECTION=sync` 前提のコードか確認
+- **N+1**: 申込一覧（`ApplicationController::index`）で `site` を `with()` しているか
+- **設定**: 環境依存値（ホスト名、パス、認証情報）は `config/*.php` + `.env`。コードに直書きなら Medium
+- **テスト**: `tests/Feature/` に変更した Controller/Service の Feature テストがあるか。
+  外部 HTTP は `Http::fake()`、ストレージは `Storage::fake()`、画面テストは `$this->withoutVite()`
+- **後方互換**: プラグインのバージョン差（2.9.13 / 2.9.15 / 2.9.16+）を壊していないか。
+  `plugin_version` は診断用で、無い（旧バージョン）ケースを常に考慮する
+
+## 4. スタイル（Low）
+
+- `vendor/bin/pint --test <files>` の結果。修正はユーザーの承認後に `vendor/bin/pint <files>`
+- 既存コードは `if($x){` 形式など Pint 非準拠の箇所が多い。**差分行以外の整形は指摘しない**
+- 未使用 `use`、日本語メッセージの表記ゆれ（例: 「５万円」の全角数字）、typo（`$suevey_type`）は Low
+
+## 5. baseline 候補（初回にユーザーへ確認する。勝手に許容扱いにしない）
+
+差分範囲外で既に存在し、設計判断または暫定運用の可能性があるもの:
+
+- `POST /api/applications` / `GET /api/applications` が認証なし（プラグインからの申込受付口）
+- `routes/web.php` の `/box`, `/box/oauth` ルートが `auth` 無し・クロージャ実装
+- `BasicAuthMiddleware` の認証情報ハードコード（`/dashboard` の追加保護）
+- `Api\ApplicationController::create` がバリデーション無しで `$request->*` を保存
+- `User` の `MustVerifyEmail` がコメントアウト（`docs/issues/smtp-connection-error.md`）
+- `config/mail.php` の `timeout => null`
+- `tests/Feature/*` の Vite manifest 依存による既存失敗
+
+これらを baseline に入れるか backlog（Issue 化）にするかはユーザーの判断。
+baseline に入れたものは以後のラウンドで指摘しない。
+
+## 6. コマンド早見表
+
+```bash
+# 差分の基点
+BASE=$(git merge-base origin/main HEAD)          # フィーチャーブランチ
+git diff --stat $BASE                             # 対象ファイル一覧（working tree 含む）
+
+# スナップショット（ブランチ・working tree を変更しない）
+SNAP=$(git stash create "padiy-review R1 target"); echo ${SNAP:-$(git rev-parse HEAD)}
+git diff <SNAP>                                   # スナップショット以降の差分
+
+# 静的チェック
+git diff --name-only $BASE -- '*.php' | xargs -I{} php -l {}
+git diff --name-only $BASE -- '*.php' | xargs vendor/bin/pint --test
+
+# テスト（MySQL 不要）
+DB_CONNECTION=sqlite DB_DATABASE=":memory:" php artisan test
+DB_CONNECTION=sqlite DB_DATABASE=":memory:" php artisan test --filter=CsvImportTest
+
+# プラグイン側の受信コードを参照（ローカルは権限で読めない）
+gh api repos/artisanworkshop/Japanized-for-WooCommerce/contents/includes/gateways/paidy/class-wc-paidy-apply-receiver.php \
+  -q .content | base64 -d | less
+```

--- a/app/Http/Controllers/Api/ApplicationController.php
+++ b/app/Http/Controllers/Api/ApplicationController.php
@@ -53,6 +53,10 @@ class ApplicationController extends Controller
         if(is_numeric($set_num))$set_num++;
         $set_num = sprintf('%08d', $set_num);
         $application_id = 'WC'.$set_num.'1';
+        // 申込元プラグインのバージョン（2.9.16 以降が送信。旧バージョンは null）。診断用。
+        $plugin_version = is_string($request->plugin_version)
+            ? substr(preg_replace('/[^0-9A-Za-z.\-+]/', '', $request->plugin_version), 0, 20)
+            : '';
         $save_app_data = array(
             'application_id' => $application_id,
             'site_id' => $site_id,
@@ -64,6 +68,7 @@ class ApplicationController extends Controller
             'gmv_flag' => $request->gmv_flag,
             'average_flag' => $request->average_flag,
             'state' => $request->state,
+            'plugin_version' => $plugin_version !== '' ? $plugin_version : null,
         );
         $application = Application::create( $save_app_data );
         Log::info('Create application.');
@@ -183,10 +188,32 @@ class ApplicationController extends Controller
             $survey06,// JCAアンケート14
             $request->survey07,// JCAアンケート入力欄02
         );
+        // ここから先（CSV 追記）で失敗しても申込は DB に登録済みなので 200 を返す。
+        // 5xx を返すとプラグイン側が「申込は届かなかった」と判断して state トークンを削除し、
+        // 後の審査結果送信が 403 (paidy_invalid_state) になる（孤児トークン）。
+        try {
+            $this->appendMerchantListCsv($file_url, $csv_data);
+        } catch (\Throwable $e) {
+            Log::error('Merchant list CSV append failed for ' . $application_id . ': ' . $e->getMessage());
+        }
+
+        return response()->json($application);
+    }
+
+    /**
+     * Box 転送用の加盟店リスト CSV に 1 行追記する（初回はヘッダー付きで新規作成）。
+     *
+     * @throws \RuntimeException ファイルを開けない場合
+     */
+    private function appendMerchantListCsv(string $file_url, array $csv_data): void
+    {
         if(file_exists($file_url)){
-            $fp = fopen($file_url, 'a');
+            $fp = @fopen($file_url, 'a');
         }else{
-            $fp = fopen($file_url, 'w');
+            $fp = @fopen($file_url, 'w');
+            if ($fp === false) {
+                throw new \RuntimeException('fopen failed: ' . $file_url);
+            }
             fwrite($fp, "\xEF\xBB\xBF");
             fputcsv($fp,
                 array(
@@ -245,10 +272,11 @@ class ApplicationController extends Controller
                 )
             );
         }
+        if ($fp === false) {
+            throw new \RuntimeException('fopen failed: ' . $file_url);
+        }
         fputcsv($fp, $csv_data);
         fclose($fp);
-
-        return response()->json($application);
     }
 
     public function update(ApplicationRequest $request, Application $application)

--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -4,8 +4,60 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Application;
+use App\Services\PaidyCallbackSender;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+
 class ApplicationController extends Controller
 {
+    public function __construct(private PaidyCallbackSender $sender)
+    {
+    }
+
+    /**
+     * 審査結果を加盟店サイトへ再送信する（CSV の再アップロード不要）。
+     * DB に保存済みの paidy_status とキーを使って PaidyCallbackSender で 1 件だけ送る。
+     */
+    public function resend(Application $application)
+    {
+        if (empty($application->paidy_status)) {
+            return redirect()->route('application.index')
+                ->with('error', $application->application_id . ': 審査結果が未登録のため再送信できません。先に CSV を取り込んでください。');
+        }
+
+        $site = DB::table('sites')->where('id', $application->site_id)->select('site_url', 'site_hash')->first();
+        if (!$site) {
+            return redirect()->route('application.index')
+                ->with('error', $application->application_id . ': サイト情報（site_id: ' . $application->site_id . '）が見つかりません。');
+        }
+
+        $result = $this->sender->send(
+            $application->application_id,
+            $application->paidy_status,
+            [
+                'public_live_key' => $application->public_live_key,
+                'secret_live_key' => $application->secret_live_key,
+                'public_test_key' => $application->public_test_key,
+                'secret_test_key' => $application->secret_test_key,
+            ],
+            $site,
+            $application->state,
+            $application->plugin_version
+        );
+
+        $application->set_status = $result['success'] ? 1 : 0;
+        $application->updated_at = Carbon::now();
+        $application->save();
+
+        if ($result['success']) {
+            return redirect()->route('application.index')
+                ->with('status', $application->application_id . ': 再送信に成功しました（HTTP ' . $result['status'] . '）。');
+        }
+
+        return redirect()->route('application.index')
+            ->with('error', $application->application_id . ': 再送信に失敗しました。' . $result['error']);
+    }
+
     public function index( Request $request ){
         $application_id = $request->input('application_id');
         $site_name = $request->input('site_name');

--- a/app/Http/Controllers/CsvImportController.php
+++ b/app/Http/Controllers/CsvImportController.php
@@ -6,12 +6,16 @@ use Illuminate\Http\Request;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Carbon\Carbon;
+use App\Services\PaidyCallbackSender;
 
 class CsvImportController extends Controller
 {
+    public function __construct(private PaidyCallbackSender $sender)
+    {
+    }
+
     public function import(Request $request)
     {
         // バリデーション
@@ -103,7 +107,7 @@ class CsvImportController extends Controller
                             // applicationsテーブルからsite_idとstateを取得
                             $application = DB::table('applications')
                                 ->where('application_id', $row[0])
-                                ->select('site_id', 'state')
+                                ->select('site_id', 'state', 'plugin_version')
                                 ->first();
 
                             if (!$application) {
@@ -128,77 +132,36 @@ class CsvImportController extends Controller
                                 continue;
                             }
 
-                            // stateトークンが無い申込は受信側で必ず403になるため送信しない
-                            if (empty($application->state)) {
-                                DB::table('applications')->where('application_id', $row[0])->update([
-                                    'set_status' => 0,
-                                    'updated_at' => Carbon::now()
-                                ]);
+                            $result = $this->sender->send(
+                                $row[0],
+                                $row[1],
+                                [
+                                    'public_live_key' => $row[2],
+                                    'secret_live_key' => $row[3],
+                                    'public_test_key' => $row[4],
+                                    'secret_test_key' => $row[5],
+                                ],
+                                $site,
+                                $application->state,
+                                $application->plugin_version
+                            );
 
-                                $api_error_list[] = [
-                                    'application_id' => $row[0],
-                                    'site_url' => $site->site_url,
-                                    'error' => 'stateトークン未保存の申込です（旧バージョンのプラグインからの申込）。自動送信できないため、加盟店側での手動キー設定または再申込が必要です。'
-                                ];
-                                continue;
-                            }
-                            // site_hashを使って暗号化キーとIVを生成
-                            $method = 'AES-256-CBC';
-                            $key = substr(hash('sha256', $site->site_hash), 0, 32);
-                            $iv = substr(hash('sha256', $site->site_hash . 'iv'), 0, 16);
-
-                            // 各キーを暗号化
-                            $encryptedPublicLiveKey = base64_encode(openssl_encrypt($row[2], $method, $key, OPENSSL_RAW_DATA, $iv));
-                            $encryptedSecretLiveKey = base64_encode(openssl_encrypt($row[3], $method, $key, OPENSSL_RAW_DATA, $iv));
-                            $encryptedPublicTestKey = base64_encode(openssl_encrypt($row[4], $method, $key, OPENSSL_RAW_DATA, $iv));
-                            $encryptedSecretTestKey = base64_encode(openssl_encrypt($row[5], $method, $key, OPENSSL_RAW_DATA, $iv));
-
-                            if( "/" === substr($site->site_url, -1)){
-                                $site_url = $site->site_url;
-                            }else{
-                                $site_url = $site->site_url . '/';
-                            }
-                            $response = Http::post( $site_url.'wp-json/paidy-receiver/v1/receive/', [
-                                'application_id' => $row[0],
-                                'paidy_status' => $row[1],
-                                'public_live_key' => $encryptedPublicLiveKey,
-                                'secret_live_key' => $encryptedSecretLiveKey,
-                                'public_test_key' => $encryptedPublicTestKey,
-                                'secret_test_key' => $encryptedSecretTestKey,
-                                'state' => $application->state,
-                                'updated_at' => Carbon::now()->toDateTimeString()
+                            DB::table('applications')->where('application_id', $row[0])->update([
+                                'set_status' => $result['success'] ? 1 : 0,
+                                'updated_at' => Carbon::now()
                             ]);
 
-                            if ($response->successful()) {
-                                $set_result = DB::table('applications')->where('application_id', $row[0])->update([
-                                    'set_status' => 1,
-                                    'updated_at' => Carbon::now()
-                                ]);
-
+                            if ($result['success']) {
                                 $api_success_list[] = [
                                     'application_id' => $row[0],
-                                    'site_url' => $site_url,
-                                    'status' => $response->status()
+                                    'site_url' => $result['site_url'],
+                                    'status' => $result['status']
                                 ];
                             } else {
-                                $set_result = DB::table('applications')->where('application_id', $row[0])->update([
-                                    'set_status' => 0,
-                                    'updated_at' => Carbon::now()
-                                ]);
-
-                                $error_code = $response->json('code');
-                                if ($error_code === 'paidy_invalid_state') {
-                                    $api_error = '加盟店サイト側のstateトークンが期限切れまたは消滅しています。加盟店にプラグイン最新版への更新と再申込、または手動キー設定を案内してください。';
-                                } elseif ($error_code === 'paidy_not_configured') {
-                                    $api_error = '加盟店サイトのPaidy受信設定（site_hash）が未設定です。';
-                                } else {
-                                    $api_error = 'HTTPステータス: ' . $response->status() . ' - ' . $response->body();
-                                }
-
                                 $api_error_list[] = [
                                     'application_id' => $row[0],
-                                    'site_url' => $site_url,
-                                    'error' => $api_error
+                                    'site_url' => $result['site_url'],
+                                    'error' => $result['error']
                                 ];
                             }
                         } catch (\Exception $e) {

--- a/app/Services/PaidyCallbackSender.php
+++ b/app/Services/PaidyCallbackSender.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Carbon\Carbon;
+
+/**
+ * 加盟店サイト（Japanized for WooCommerce）の受信エンドポイントへ審査結果と API キーを送信する。
+ *
+ * CSV 取込（CsvImportController）と申込一覧の「再送信」（ApplicationController::resend）で共用する。
+ *
+ * 認証は 2 系統:
+ *  - state トークン（申込時にプラグインが発行。2.9.13–2.9.14 は 2 日で失効、2.9.15 は 90 日）
+ *  - HMAC-SHA256 署名（`<timestamp>.<raw body>` を site_hash で署名。プラグイン 2.9.16+ が検証）
+ * 両方を常に送り、受信側はどちらか一方が通れば受理する。
+ */
+class PaidyCallbackSender
+{
+    public const RECEIVE_PATH = 'wp-json/paidy-receiver/v1/receive/';
+
+    /**
+     * @param string      $applicationId 申込番号（WC000000571 など）
+     * @param string      $paidyStatus   approved / rejected / canceled
+     * @param array       $keys          public_live_key, secret_live_key, public_test_key, secret_test_key（平文）
+     * @param object      $site          site_url, site_hash を持つオブジェクト
+     * @param string|null $state         申込時の state トークン（無ければ null）
+     * @param string|null $pluginVersion 申込時のプラグインバージョン（エラー文の補足に使う）
+     * @return array{success: bool, status: int|null, site_url: string, error: string|null}
+     */
+    public function send(
+        string $applicationId,
+        string $paidyStatus,
+        array $keys,
+        object $site,
+        ?string $state = null,
+        ?string $pluginVersion = null
+    ): array {
+        $siteUrl = rtrim($site->site_url, '/') . '/';
+
+        // site_hash から AES-256-CBC の鍵と IV を導出（受信側と同じ導出式）
+        $method = 'AES-256-CBC';
+        $aesKey = substr(hash('sha256', $site->site_hash), 0, 32);
+        $aesIv = substr(hash('sha256', $site->site_hash . 'iv'), 0, 16);
+
+        $payload = [
+            'application_id' => $applicationId,
+            'paidy_status' => $paidyStatus,
+            'updated_at' => Carbon::now()->toDateTimeString(),
+        ];
+        foreach (['public_live_key', 'secret_live_key', 'public_test_key', 'secret_test_key'] as $field) {
+            $payload[$field] = base64_encode(
+                openssl_encrypt((string) ($keys[$field] ?? ''), $method, $aesKey, OPENSSL_RAW_DATA, $aesIv)
+            );
+        }
+        // state トークンは従来通り送る（プラグイン 2.9.15 以前はこれだけで検証する）。
+        if (!empty($state)) {
+            $payload['state'] = $state;
+        }
+
+        // 本文を site_hash で HMAC-SHA256 署名する。署名対象の文字列と送信本文は完全に一致させること。
+        $body = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $timestamp = (string) time();
+        $signature = hash_hmac('sha256', $timestamp . '.' . $body, $site->site_hash);
+
+        try {
+            $response = Http::withHeaders([
+                'X-Paidy-Receiver-Timestamp' => $timestamp,
+                'X-Paidy-Receiver-Signature' => $signature,
+            ])->withBody($body, 'application/json')
+              ->post($siteUrl . self::RECEIVE_PATH);
+        } catch (\Throwable $e) {
+            Log::warning('Paidy callback send failed: ' . $applicationId . ' ' . $e->getMessage());
+            return [
+                'success' => false,
+                'status' => null,
+                'site_url' => $siteUrl,
+                'error' => '加盟店サイトへ接続できませんでした: ' . $e->getMessage(),
+            ];
+        }
+
+        if ($response->successful()) {
+            return ['success' => true, 'status' => $response->status(), 'site_url' => $siteUrl, 'error' => null];
+        }
+
+        return [
+            'success' => false,
+            'status' => $response->status(),
+            'site_url' => $siteUrl,
+            'error' => $this->translateError($response->json('code'), $response->status(), $response->body(), $pluginVersion),
+        ];
+    }
+
+    private function translateError(mixed $code, int $status, string $body, ?string $pluginVersion): string
+    {
+        // 受信側が想定外の型（数値・配列）の code を返しても TypeError にせず、汎用メッセージに落とす。
+        if (!is_string($code)) {
+            $code = null;
+        }
+        if ($code === 'paidy_invalid_state') {
+            return '加盟店サイト側のstateトークンが期限切れまたは消滅しており、プラグインが署名検証に未対応（2.9.16 未満）です。'
+                . '加盟店にプラグイン最新版への更新を案内し、更新後にこの申込を再送信してください（再申込は不要）。'
+                . '更新できない場合は手動キー設定を案内してください。'
+                . '（申込時のプラグイン: ' . ($pluginVersion ?: '不明（2.9.15 以前）') . '）';
+        }
+        if ($code === 'paidy_not_configured') {
+            return '加盟店サイトのPaidy受信設定（site_hash）が未設定です。';
+        }
+        return 'HTTPステータス: ' . $status . ' - ' . $body;
+    }
+}

--- a/database/migrations/2026_08_28_000000_add_plugin_version_to_applications_table.php
+++ b/database/migrations/2026_08_28_000000_add_plugin_version_to_applications_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * 申込時のプラグインバージョンを記録する。
+     * state トークンの扱いがバージョンで異なる（≤2.9.12: 未送信 / 2.9.13–2.9.14: 2日 transient /
+     * 2.9.15: 90日 option / 2.9.16+: 署名検証あり）ため、CSV 取込失敗時の切り分けに使う。
+     */
+    public function up(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->string('plugin_version', 20)->nullable()->default(null)->after('state');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->dropColumn('plugin_version');
+        });
+    }
+};

--- a/docs/review-backlog.md
+++ b/docs/review-backlog.md
@@ -1,0 +1,11 @@
+# レビューバックログ（今回対応しない指摘）
+| 追記日 | ID | 重大度 | 場所 | 内容 | 起票状況 |
+|---|---|---|---|---|---|
+| 2026-08-28 | R1-X1 | High | routes/auth.php:15-18 | `/register` が開放されており、任意のユーザーが管理画面（申込一覧・再送信・CSV 取込）にアクセス可能。前段保護の有無を確認し、無ければ登録ルートを閉じる | 未起票（要確認） |
+| 2026-08-28 | R1-X2 | High | app/Http/Controllers/CsvImportController.php:22-24 | ファイルバリデーションがコメントアウトのまま。未選択送信で 500 | docs/issues/csv-import-null-error.md |
+| 2026-08-28 | R1-X3 | Medium | app/Http/Controllers/CsvImportController.php:169 | 行ループの `catch (\Exception)` を `\Throwable` に広げ、1行の `\Error` で取込全体が 500 にならないようにする | 未起票 |
+| 2026-08-28 | R1-L1 | Low | PHP 差分 7ファイル | Pint スタイル指摘（array_syntax, concat_space 等）。一括整形するかは要判断 | 未起票 |
+| 2026-08-28 | R1-L2 | Low | app/Http/Controllers/ApplicationController.php:29 | `DB::table('sites')` ではなく `$application->site` リレーションを使う | 未起票 |
+| 2026-08-28 | R1-L3 | Low | app/Services/PaidyCallbackSender.php:68 | `Http::timeout(15)` 程度を明示（既定 30 秒 × CSV 行数の待ちを短縮） | 未起票 |
+| 2026-08-28 | R1-L4 | Low | app/Services/PaidyCallbackSender.php:97-102 | `paidy_invalid_state` の案内文に 2.9.16+ での署名不一致（site_hash 相違・時刻ずれ）の可能性を併記 | 未起票 |
+| 2026-08-28 | R2-L1 | Low | app/Http/Controllers/Api/ApplicationController.php:216 | 加盟店リスト CSV のパスを `storage_path()` 直書きから `Storage::disk('local')`/config 経由にし、テストで差し替え可能にする（ApiApplicationCreateTest の実ファイル退避を不要にする） | 未起票 |

--- a/docs/review-baseline.md
+++ b/docs/review-baseline.md
@@ -1,0 +1,15 @@
+# レビューベースライン（許容済み指摘リスト）
+レビュー時、ここに記載された項目は指摘しないこと。
+
+## 形式
+- [カテゴリ] 対象範囲 — 許容理由
+
+## 許容項目
+<!-- 以下は候補。ユーザー確認のうえコメントを外して有効化する
+- [Auth] POST /api/applications が認証なし — WooCommerce プラグインからの申込受付口のため（後続は site_hash で暗号化・署名）
+- [Auth] routes/auth.php の /register 開放 — 本番は前段の Basic 認証で保護している場合のみ
+- [Legacy] routes/web.php の /box, /box/oauth ルートが auth 無し・クロージャ実装 — 手動運用の暫定ルート
+- [Legacy] BasicAuthMiddleware の認証情報ハードコード — /dashboard の追加保護
+- [Test] tests/Feature/* の Vite manifest 未ビルドによる既存失敗 7件 — ローカルでは public/build を生成しない運用
+- [Style] 既存コードの Pint 非準拠（if(...){ 形式等） — 差分行以外は整形しない
+-->

--- a/docs/reviews/fix-signed-callback-resend/R1.md
+++ b/docs/reviews/fix-signed-callback-resend/R1.md
@@ -1,0 +1,39 @@
+# R1 レビュー結果
+- ブランチ: `fix/signed-callback-resend`
+- 対象: `ce95bae`（= origin/main）...`ce95bae` + working tree（対象SNAP: `ad662dd198f0f6903553acb272d2a08e37502a07`）
+- 判定: **APPROVE**（新規 Critical/High なし。Medium 2件は本ラウンドで修正）
+- 自動チェック: php -l OK（9ファイル） / pint --test 7ファイルにスタイル指摘（Low） / test 23 passed, 7 failed（既知: Vite manifest 未ビルド 7件。差分由来の失敗なし）、deprecation は vendor/PHP 8.5 由来のみ
+- 外部契約の突き合わせ: プラグイン側 PR artisanworkshop/Japanized-for-WooCommerce#211（OPEN, `fix/paidy-receiver-signature-fallback`）の `verify_request_signature()` と照合済み
+  - ヘッダー `x-paidy-receiver-signature` / `x-paidy-receiver-timestamp` ✓
+  - 署名対象 `<timestamp>.<raw body>`、鍵 = `site_hash` 生値、HMAC-SHA256 64桁小文字hex ✓
+  - timestamp `^[0-9]{1,12}$`、許容 10分 ✓／本文は `withBody($body, 'application/json')` で署名対象と完全一致 ✓
+  - 受信側は state 検証を先に行い、使えない場合のみ署名にフォールバック → 本差分が state と署名を常に両方送る設計と整合 ✓
+  - **注意**: upstream `main`（2.9.15）には署名検証が無い。PR #211（2.9.16 予定）が先にリリースされる前提（PR 本文の rollout 順: plugin → paidy-app）
+
+## 指摘
+
+### [R1-1][Medium][app/Services/PaidyCallbackSender.php:96]
+`translateError(?string $code, ...)` に `$response->json('code')` をそのまま渡している。加盟店サイトが `{"code": 403}` のような数値/配列の `code` を返すと `TypeError` になる。`TypeError` は `\Error` なので `CsvImportController` の `catch (\Exception)` を素通りし、**CSV 取込全体・再送信が 500** になる。
+**修正方針:** `$code` を `mixed` で受け、`is_string` でなければ `null` に正規化する
+→ 修正済み: `app/Services/PaidyCallbackSender.php` `translateError()` 冒頭で正規化
+
+### [R1-2][Medium][app/Http/Controllers/Api/ApplicationController.php:56-72, 191-199]
+`plugin_version` のサニタイズ/保存と「CSV 追記失敗でも 200 を返す」変更に Feature テストが無い。後者は孤児 state トークンを防ぐ契約なので、回帰検知が必要。
+**修正方針:** `tests/Feature/ApiApplicationCreateTest.php` を追加（plugin_version の正規化・旧プラグインの null・申込番号形式・CSV 追記失敗時の 200）。Controller が `storage_path('box_data')` 直書きのため、テスト内で実 CSV を退避/復元する
+→ 修正済み: `tests/Feature/ApiApplicationCreateTest.php`（新規）
+
+## 対象外指摘（差分範囲外）
+- [R1-X1][High][routes/auth.php:15-18] `/register` が開放されており、誰でもアカウントを作って `/application`（キー末尾4桁のマスク表示）・再送信・CSV 取込を実行できる。本番で Basic 認証等の前段保護があるなら baseline へ、無ければ Issue 化を推奨
+- [R1-X2][High][app/Http/Controllers/CsvImportController.php:22-24] ファイルバリデーションがコメントアウトのままで、未選択送信で 500（`docs/issues/csv-import-null-error.md` 起票済み・未対応）
+- [R1-X3][Medium][app/Http/Controllers/CsvImportController.php:169] 行ループの `catch (\Exception $e)` が `\Error`（TypeError 等）を捕捉しない。1行の想定外エラーで取込全体が 500 になる。`\Throwable` への変更を推奨
+
+## Low（backlogへ）
+- [R1-L1][Low][全PHP差分] Pint スタイル指摘 7ファイル（array_syntax, concat_space, single_space_around_construct 等）。既存コードのスタイルに合わせているため一括整形はユーザー判断
+- [R1-L2][Low][app/Http/Controllers/ApplicationController.php:29] `DB::table('sites')` 直接クエリ。`Application::site()` リレーションが定義済みなので `$application->site` で取得できる
+- [R1-L3][Low][app/Services/PaidyCallbackSender.php:68] `Http::` に明示的な `timeout()` が無い（Laravel 既定 30 秒は効く）。CSV 取込は行数×最大30秒になるため `timeout(15)` 程度の明示を推奨
+- [R1-L4][Low][app/Services/PaidyCallbackSender.php:97-102] `paidy_invalid_state` の案内文が「2.9.16 未満」前提。2.9.16 以上でも署名不一致（site_hash 相違・10分超の時刻ずれ）で同じコードが返るため、その可能性も併記すると運用者の切り分けが早い
+
+## 修正後
+- 修正後テスト: 28 passed, 7 failed（既知の Vite 7件のみ）、新規テスト 5件追加（ApiApplicationCreateTest ×4、ApplicationResendTest ×1）
+- 修正後SNAP: `bc9eebb2a5516c37f0479e52a14669ff88846b31`
+- 修正ファイル: app/Services/PaidyCallbackSender.php, tests/Feature/ApplicationResendTest.php, tests/Feature/ApiApplicationCreateTest.php（新規）

--- a/docs/reviews/fix-signed-callback-resend/R2.md
+++ b/docs/reviews/fix-signed-callback-resend/R2.md
@@ -1,0 +1,20 @@
+# R2 レビュー結果（検証モード）
+- ブランチ: `fix/signed-callback-resend`
+- 対象: R1 対象SNAP `ad662dd` → R1 修正後SNAP `bc9eebb` の差分のみ（app/Services/PaidyCallbackSender.php、tests/Feature/ApplicationResendTest.php、tests/Feature/ApiApplicationCreateTest.php[新規]）
+- 判定: **APPROVE**（新規 Critical/High なし → ループ終了）
+- 自動チェック: php -l OK / pint 3ファイルにスタイル指摘（R1-L1 と同種、Low） / test 28 passed, 7 failed（既知: Vite 7件）
+
+## R1 指摘の解消判定
+| ID | 重大度 | 判定 |
+|---|---|---|
+| R1-1 | Medium | 解消 — `translateError(mixed $code, ...)` + `is_string` ガードで非文字列 `code` を `null` に正規化。文言・ヘッダー・ペイロードは不変で外部契約への影響なし。回帰テスト `test_non_string_error_code_from_merchant_site_does_not_crash` が 403 + `{"code":403}` で 500 にならず `set_status=0` になることを検証 |
+| R1-2 | Medium | 解消 — `ApiApplicationCreateTest` ×4（plugin_version の正規化/20文字切詰、旧プラグイン・配列入力で null、申込番号の採番、CSV 追記失敗時の 200）。`storage_path('box_data')` 直書きのため実 CSV を退避/復元し、実 CSV が存在する環境では追記失敗テストを skip する |
+
+## 指摘
+（新規 Critical/High/Medium なし）
+
+## 対象外指摘（差分範囲外）
+（なし）
+
+## Low（backlogへ）
+- [R2-L1][Low][tests/Feature/ApiApplicationCreateTest.php:24-45] 実ファイルの退避/復元は fatal error で tearDown が走らないと復元されない。根本対策は Controller の CSV パスを `config()` / `Storage::disk('local')` 経由にしてテストで差し替え可能にすること（R1-2 の備考）

--- a/resources/views/application/index.blade.php
+++ b/resources/views/application/index.blade.php
@@ -5,6 +5,12 @@
         </h2>
     </x-slot>
     <div class="mx-auto px-6">
+        @if (session('status'))
+        <div class="mt-4 p-4 bg-success w-full rouded-2xl" style="color:#fff">{{ session('status') }}</div>
+        @endif
+        @if (session('error'))
+        <div class="mt-4 p-4 bg-danger w-full rouded-2xl" style="color:#fff">{{ session('error') }}</div>
+        @endif
         <div class="mt-4 p-8 bg-white w-full rouded-2xl">
             <a href="/import-csv" class="btn btn-primary">インポート</a>
             <!-- Search function start here -->
@@ -69,7 +75,7 @@
             <!--Search function ends here -->
                     <table class="table">
                 <thead class="thead-primary">
-                    <tr><th>申込番号</th><th>サイト名</th><th>会社名</th><th>サイトURL</th><th>ステータス</th><th>送信結果</th><th>申込日時</th><th>更新日時</th></tr>
+                    <tr><th>申込番号</th><th>サイト名</th><th>会社名</th><th>サイトURL</th><th>ステータス</th><th>送信結果</th><th>プラグインVer</th><th>申込日時</th><th>更新日時</th><th>再送信</th></tr>
                 </thead>
                 <tbody>
                 @foreach ($applications as $application)
@@ -98,6 +104,7 @@
                         失敗
                         @endif
                     </td>
+                    <td>{{ $application->plugin_version ?? '-' }}</td>
                     <td>@if($application->created_at != null )
                         {{$application->created_at->format('Y年n月d日 G:i')}}
                         @endif
@@ -105,6 +112,17 @@
                     <td>@isset($application->updated_at)
                         {{$application->updated_at->format('Y年n月d日 G:i')}}
                         @endisset
+                    </td>
+                    <td>
+                        @if ($application->paidy_status != null)
+                        <form action="{{ route('application.resend', $application->id) }}" method="POST"
+                              onsubmit="return confirm('{{ $application->application_id }} の審査結果を加盟店サイトへ再送信します。よろしいですか？');">
+                            @csrf
+                            <button type="submit" class="btn btn-sm {{ $application->set_status == 1 ? 'btn-outline-secondary' : 'btn-warning' }}">再送信</button>
+                        </form>
+                        @else
+                        -
+                        @endif
                     </td>
                 </tr>
                 @isset($application->public_live_key)

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,6 +38,7 @@ Route::middleware('auth')->group(function () {
     Route::get('import-csv', [CsvImportController::class,'show'])->name('import-csv.show');
     Route::post('import-csv',  [CsvImportController::class,'import']);
     Route::get('application', [ApplicationController::class, 'index'])->name('application.index');
+    Route::post('application/{application}/resend', [ApplicationController::class, 'resend'])->name('application.resend');
     Route::get('sftp-upload', [PaidyConnectController::class, 'index'])->name('sftp-upload.index');
 });
 

--- a/tests/Feature/ApiApplicationCreateTest.php
+++ b/tests/Feature/ApiApplicationCreateTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * POST /api/applications（プラグインの申込ウィザードからの受付口）のテスト。
+ *
+ * Api\ApplicationController は storage_path('box_data') 直書きで加盟店リスト CSV に追記するため、
+ * 実ファイルを setUp で退避し tearDown で復元する。
+ */
+class ApiApplicationCreateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $csvPath;
+    private bool $csvExisted = false;
+    private ?string $csvBackup = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->csvPath = storage_path('box_data') . '/woocommerce_merchant_list.csv';
+        $this->csvExisted = file_exists($this->csvPath) && !is_dir($this->csvPath);
+        if ($this->csvExisted) {
+            $this->csvBackup = file_get_contents($this->csvPath);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->csvPath)) {
+            rmdir($this->csvPath);
+        }
+        if ($this->csvExisted) {
+            file_put_contents($this->csvPath, $this->csvBackup);
+        } elseif (file_exists($this->csvPath)) {
+            unlink($this->csvPath);
+        }
+        parent::tearDown();
+    }
+
+    private function payload(array $overrides = []): array
+    {
+        return array_merge([
+            'site_name' => 'テストショップ',
+            'site_url' => 'https://example-shop.test',
+            'trade_name' => 'テスト商店',
+            'site_hash' => hash('sha256', 'test-site-hash'),
+            'email' => 'merchant@example-shop.test',
+            'phone' => '0312345678',
+            'ceo' => '山田 太郎',
+            'ceo_kana' => 'ヤマダ タロウ',
+            'ceo_birthday' => '1980-01-01',
+            'gmv_flag' => 1,
+            'average_flag' => 1,
+            'state' => 'a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6',
+            'survey01' => 'yes',
+            'survey08' => 'yes',
+            'survey09' => 'no',
+        ], $overrides);
+    }
+
+    public function test_plugin_version_is_sanitized_and_stored(): void
+    {
+        $response = $this->postJson('/api/applications', $this->payload([
+            'plugin_version' => "2.9.16-beta.1 <b>x</b>\n" . str_repeat('9', 30),
+        ]));
+
+        $response->assertOk();
+        $response->assertJsonPath('site_id', DB::table('sites')->where('site_url', 'https://example-shop.test')->value('id'));
+        $this->assertMatchesRegularExpression('/^WC[0-9]{8}1$/', $response->json('application_id'));
+
+        // 許可文字（英数字 . - +）以外を除去し 20 文字に切り詰める
+        $stored = DB::table('applications')->where('application_id', $response->json('application_id'))->value('plugin_version');
+        $this->assertSame(20, strlen($stored));
+        $this->assertStringStartsWith('2.9.16-beta.1bxb9', $stored);
+        $this->assertMatchesRegularExpression('/^[0-9A-Za-z.\-+]+$/', $stored);
+    }
+
+    public function test_application_from_old_plugin_stores_null_plugin_version(): void
+    {
+        $withoutVersion = $this->postJson('/api/applications', $this->payload());
+        $withoutVersion->assertOk();
+        $this->assertNull(DB::table('applications')->where('application_id', $withoutVersion->json('application_id'))->value('plugin_version'));
+
+        $arrayVersion = $this->postJson('/api/applications', $this->payload(['plugin_version' => ['2.9.16']]));
+        $arrayVersion->assertOk();
+        $this->assertNull(DB::table('applications')->where('application_id', $arrayVersion->json('application_id'))->value('plugin_version'));
+    }
+
+    public function test_application_id_increments_from_latest_application(): void
+    {
+        $site_id = DB::table('sites')->insertGetId([
+            'site_name' => '既存ショップ',
+            'site_url' => 'https://existing-shop.test',
+            'trade_name' => '既存商店',
+            'site_hash' => hash('sha256', 'existing'),
+            'created_at' => Carbon::now()->subDay(),
+            'updated_at' => Carbon::now()->subDay(),
+        ]);
+        DB::table('applications')->insert([
+            'application_id' => 'WC000005711',
+            'site_id' => $site_id,
+            'email' => 'existing@existing-shop.test',
+            'phone' => '0300000000',
+            'ceo' => '既存 太郎',
+            'ceo_kana' => 'キゾン タロウ',
+            'ceo_birthday' => '1970-01-01',
+            'gmv_flag' => 0,
+            'average_flag' => 0,
+            'created_at' => Carbon::now()->subDay(),
+            'updated_at' => Carbon::now()->subDay(),
+        ]);
+
+        $response = $this->postJson('/api/applications', $this->payload());
+
+        $response->assertOk();
+        $this->assertSame('WC000005721', $response->json('application_id'));
+    }
+
+    public function test_merchant_list_csv_failure_still_returns_200_so_plugin_keeps_state_token(): void
+    {
+        if ($this->csvExisted) {
+            $this->markTestSkipped('実際の加盟店リスト CSV が存在する環境では追記失敗を再現しない。');
+        }
+        // CSV のパスにディレクトリを置くと fopen が失敗し appendMerchantListCsv() が例外を投げる
+        mkdir($this->csvPath);
+
+        $response = $this->postJson('/api/applications', $this->payload());
+
+        // 5xx を返すとプラグインが state トークンを破棄して後の審査結果送信が 403 になるため、200 が契約
+        $response->assertOk();
+        $this->assertDatabaseHas('applications', [
+            'application_id' => $response->json('application_id'),
+            'state' => 'a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6',
+        ]);
+    }
+}

--- a/tests/Feature/ApplicationResendTest.php
+++ b/tests/Feature/ApplicationResendTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class ApplicationResendTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const SITE_HASH = 'aB3$dE6&gH9(kL2-';
+    private const RECEIVE_URL = 'https://example-shop.test/wp-json/paidy-receiver/v1/receive/';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutVite();
+    }
+
+    private function seedApplication(?string $paidyStatus, ?string $state = null): int
+    {
+        $site_id = DB::table('sites')->insertGetId([
+            'site_name' => 'テストショップ',
+            'site_url' => 'https://example-shop.test',
+            'trade_name' => 'テスト商店',
+            'site_hash' => self::SITE_HASH,
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+
+        return DB::table('applications')->insertGetId([
+            'application_id' => 'WC000000571',
+            'site_id' => $site_id,
+            'state' => $state,
+            'plugin_version' => '2.9.14',
+            'email' => 'merchant@example-shop.test',
+            'phone' => '0312345678',
+            'ceo' => '山田 太郎',
+            'ceo_kana' => 'ヤマダ タロウ',
+            'ceo_birthday' => '1980-01-01',
+            'gmv_flag' => 0,
+            'average_flag' => 0,
+            'paidy_status' => $paidyStatus,
+            'public_live_key' => $paidyStatus === 'approved' ? 'pk_live_xxx' : null,
+            'secret_live_key' => $paidyStatus === 'approved' ? 'sk_live_xxx' : null,
+            'public_test_key' => $paidyStatus === 'approved' ? 'pk_test_xxx' : null,
+            'secret_test_key' => $paidyStatus === 'approved' ? 'sk_test_xxx' : null,
+            'set_status' => 0,
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+    }
+
+    public function test_resend_sends_signed_callback_from_stored_keys_and_marks_success(): void
+    {
+        Http::fake([self::RECEIVE_URL => Http::response(['success' => true], 200)]);
+        $id = $this->seedApplication('approved');
+
+        $response = $this->actingAs(User::factory()->create())
+            ->post(route('application.resend', $id));
+
+        $response->assertRedirect(route('application.index'));
+        $response->assertSessionHas('status');
+
+        Http::assertSent(function ($request) {
+            $payload = json_decode($request->body(), true);
+            $timestamp = $request->header('X-Paidy-Receiver-Timestamp')[0] ?? '';
+            $signature = $request->header('X-Paidy-Receiver-Signature')[0] ?? '';
+            $expected = hash_hmac('sha256', $timestamp . '.' . $request->body(), self::SITE_HASH);
+
+            // 復号して DB 保存済みのキーが送られていることを確認する
+            $aesKey = substr(hash('sha256', self::SITE_HASH), 0, 32);
+            $aesIv = substr(hash('sha256', self::SITE_HASH . 'iv'), 0, 16);
+            $decrypted = openssl_decrypt(base64_decode($payload['public_live_key']), 'AES-256-CBC', $aesKey, OPENSSL_RAW_DATA, $aesIv);
+
+            return $request->url() === self::RECEIVE_URL
+                && $payload['application_id'] === 'WC000000571'
+                && $payload['paidy_status'] === 'approved'
+                && !array_key_exists('state', $payload)
+                && $decrypted === 'pk_live_xxx'
+                && hash_equals($expected, $signature);
+        });
+
+        $this->assertDatabaseHas('applications', ['id' => $id, 'set_status' => 1]);
+    }
+
+    public function test_resend_reports_invalid_state_with_plugin_version_and_keeps_set_status_zero(): void
+    {
+        Http::fake([
+            self::RECEIVE_URL => Http::response(['code' => 'paidy_invalid_state', 'data' => ['status' => 403]], 403),
+        ]);
+        $id = $this->seedApplication('approved', 'a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6');
+
+        $response = $this->actingAs(User::factory()->create())
+            ->post(route('application.resend', $id));
+
+        $response->assertRedirect(route('application.index'));
+        $response->assertSessionHas('error', function ($message) {
+            return str_contains($message, 'stateトークンが期限切れまたは消滅')
+                && str_contains($message, '2.9.14');
+        });
+
+        $this->assertDatabaseHas('applications', ['id' => $id, 'set_status' => 0]);
+    }
+
+    public function test_resend_is_refused_before_review_result_is_registered(): void
+    {
+        Http::fake();
+        $id = $this->seedApplication(null);
+
+        $response = $this->actingAs(User::factory()->create())
+            ->post(route('application.resend', $id));
+
+        $response->assertRedirect(route('application.index'));
+        $response->assertSessionHas('error');
+        Http::assertNothingSent();
+    }
+
+    public function test_non_string_error_code_from_merchant_site_does_not_crash(): void
+    {
+        // 受信側が想定外の型の code を返しても TypeError で 500 にせず、汎用エラー文で失敗扱いにする
+        Http::fake([
+            self::RECEIVE_URL => Http::response(['code' => 403, 'message' => 'Forbidden'], 403),
+        ]);
+        $id = $this->seedApplication('approved');
+
+        $response = $this->actingAs(User::factory()->create())
+            ->post(route('application.resend', $id));
+
+        $response->assertRedirect(route('application.index'));
+        $response->assertSessionHas('error', function ($message) {
+            return str_contains($message, 'HTTPステータス: 403');
+        });
+        $this->assertDatabaseHas('applications', ['id' => $id, 'set_status' => 0]);
+    }
+
+    public function test_resend_requires_authentication(): void
+    {
+        $id = $this->seedApplication('approved');
+
+        $this->post(route('application.resend', $id))->assertRedirect(route('login'));
+    }
+}

--- a/tests/Feature/CsvImportTest.php
+++ b/tests/Feature/CsvImportTest.php
@@ -65,25 +65,51 @@ class CsvImportTest extends TestCase
             ->post('import-csv', ['file' => $file]);
     }
 
-    public function test_application_without_state_is_skipped_with_manual_action_message(): void
+    public function test_application_without_state_is_sent_signed_without_state_param(): void
     {
-        Http::fake();
+        Http::fake([
+            self::RECEIVE_URL => Http::response(['success' => true], 200),
+        ]);
         $this->seedApplication(null);
 
         $response = $this->importCsv();
 
         $response->assertOk();
-        Http::assertNothingSent();
 
-        $api_error_list = $response->viewData('api_error_list');
-        $this->assertCount(1, $api_error_list);
-        $this->assertSame('WC000000561', $api_error_list[0]['application_id']);
-        $this->assertStringContainsString('stateトークン未保存', $api_error_list[0]['error']);
+        // 旧プラグインからの申込（state 未保存）も署名付きで送信し、受信側（2.9.16+）の署名検証に委ねる。
+        Http::assertSent(function ($request) {
+            $payload = json_decode($request->body(), true);
+            return $request->url() === self::RECEIVE_URL
+                && !array_key_exists('state', $payload)
+                && $request->hasHeader('X-Paidy-Receiver-Signature')
+                && $request->hasHeader('X-Paidy-Receiver-Timestamp');
+        });
 
         $this->assertDatabaseHas('applications', [
             'application_id' => 'WC000000561',
-            'set_status' => 0,
+            'set_status' => 1,
         ]);
+    }
+
+    public function test_callback_is_signed_with_site_hash_over_timestamp_and_raw_body(): void
+    {
+        Http::fake([
+            self::RECEIVE_URL => Http::response(['success' => true], 200),
+        ]);
+        $this->seedApplication(self::VALID_STATE);
+
+        $this->importCsv()->assertOk();
+
+        Http::assertSent(function ($request) {
+            $timestamp = $request->header('X-Paidy-Receiver-Timestamp')[0] ?? '';
+            $signature = $request->header('X-Paidy-Receiver-Signature')[0] ?? '';
+            $expected = hash_hmac('sha256', $timestamp . '.' . $request->body(), hash('sha256', 'test-site-hash'));
+
+            return $request->hasHeader('Content-Type', 'application/json')
+                && preg_match('/^[0-9]+$/', $timestamp) === 1
+                && abs(time() - (int) $timestamp) < 60
+                && hash_equals($expected, $signature);
+        });
     }
 
     public function test_invalid_state_response_is_translated_to_admin_message(): void


### PR DESCRIPTION
## Summary

Companion change to artisanworkshop/Japanized-for-WooCommerce#211. Fixes the `403 paidy_invalid_state` failures when delivering Paidy review results to merchants whose onboarding state token has expired (2.9.13/2.9.14 stored it in a 2-day transient) or was never sent (<= 2.9.12).

### Changes
- **`PaidyCallbackSender`** (new): shared sender for CSV import and resend. Encrypts the four API keys with AES-256-CBC derived from `site_hash` and signs `<timestamp>.<raw body>` with HMAC-SHA256 (`X-Paidy-Receiver-Timestamp` / `X-Paidy-Receiver-Signature`). The `state` token is still sent when present, so plugins <= 2.9.15 keep working; 2.9.16+ falls back to the signature when the token is gone.
- **CSV import**: applications without a stored `state` are now sent (signed) instead of skipped.
- **`plugin_version`**: stored from the wizard POST (2.9.16+ sends it), shown in the application list and appended to the `paidy_invalid_state` operator message. Migration: `2026_08_28_000000_add_plugin_version_to_applications_table`.
- **Resend button** on the application list (`POST application/{application}/resend`): re-delivers review results from stored keys without re-importing the CSV.
- **`POST /api/applications`** returns 200 even if the merchant-list CSV append fails, so the plugin does not discard its state token (orphan-token bug).

### Review (padiy-review loop, records in `docs/reviews/fix-signed-callback-resend/`)
- R1: 0 Critical / 0 High / 2 Medium (fixed) / 4 Low (backlog) — R2: APPROVE
- R1-1: `translateError()` normalizes non-string `code` values so a merchant site returning `{"code": 403}` cannot turn a CSV import into a 500
- R1-2: `ApiApplicationCreateTest` covers `plugin_version` sanitization and the 200-on-CSV-failure contract
- Out-of-scope findings (open registration route, commented-out CSV upload validation) are tracked in `docs/review-backlog.md`
- Also adds `.claude/skills/padiy-review` (repository-specific review loop skill)

### Contract check against #211
Header names, signing string (`<timestamp>.<raw body>`), key (`site_hash` raw), 64-char lowercase hex digest, 10-minute tolerance, and state-first / signature-fallback ordering all match `verify_request_signature()` in the plugin PR.

## Rollout
**Release plugin 2.9.16 (#211) first, then deploy this.** Deploying this first does not break anything (old plugins ignore the headers), but stateless applications would fail with a message pointing merchants to update the plugin.

After deploy: `php artisan migrate`.

## Test plan
- [x] `DB_CONNECTION=sqlite DB_DATABASE=":memory:" php artisan test` — 28 passed, 7 failed (pre-existing Vite manifest failures only)
- [x] New tests: `ApplicationResendTest` x5, `ApiApplicationCreateTest` x4, `CsvImportTest` signature assertions
- [ ] Manual: import a CSV for an application with an expired state token against a 2.9.16 dev site → keys delivered, `set_status = 1`
- [ ] Manual: "再送信" from the application list for a previously failed application

🤖 Generated with [Claude Code](https://claude.com/claude-code)
